### PR TITLE
Refactor checking callvirt

### DIFF
--- a/FastAndFaster.Tests/DummyClasses/InvocationTarget.cs
+++ b/FastAndFaster.Tests/DummyClasses/InvocationTarget.cs
@@ -83,4 +83,21 @@ namespace FastAndFaster.Tests.DummyClasses
 
         public override string VirtualFunc() => ChildVirtualFuncData;
     }
+
+    public abstract class InvocationAbstractTarget
+    {
+        public abstract void ActionMultipleParams(string text, int number);
+
+        public abstract string FuncMultipleParams(string text, int number);
+    }
+
+    public class InvocationConcreteTarget : InvocationAbstractTarget
+    {
+        public int ActionMultipleParamsCalled { get; set; } = -1;
+
+        public override void ActionMultipleParams(string text, int number) =>
+            ActionMultipleParamsCalled = text.Length + number;
+
+        public override string FuncMultipleParams(string text, int number) => $"{text}:{number}";
+    }
 }

--- a/FastAndFaster.Tests/DummyClasses/InvocationTarget.cs
+++ b/FastAndFaster.Tests/DummyClasses/InvocationTarget.cs
@@ -33,7 +33,10 @@ namespace FastAndFaster.Tests.DummyClasses
 
         public string ParameterlessFuncReturnRef()
         {
+            #pragma warning disable CS0219 // Make sure that the method is not optimized away
             var dummy = "dummy";
+            #pragma warning restore CS0219
+
             return ParameterlessFuncReturnRefData;
         }
 

--- a/FastAndFaster.Tests/InvocatorGenericTests.cs
+++ b/FastAndFaster.Tests/InvocatorGenericTests.cs
@@ -55,6 +55,28 @@ namespace FastAndFaster.Tests
             target.ActionGenericArgumentsData.Should().Be(expectedRs);
         }
 
+        [Fact]
+        public void ShouldCallStaticGenericAction()
+        {
+            // Arrange
+            var typeName = typeof(InvocationGenericTarget).AssemblyQualifiedName;
+            var methodName = nameof(InvocationGenericTarget.ActionStaticGeneric);
+            var argumentTypes = new[] { typeof(string), typeof(bool) };
+            var arguments = new object[] { "JamesBond", false };
+            var genericInfo = new GenericInfo
+            {
+                GenericTypeIndex = new[] { 0, 1 },
+                GenericType = new[] { typeof(string), typeof(bool) }
+            };
+            var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes, genericInfo);
+
+            // Action
+            invocator(null, arguments);
+
+            // Assert
+            InvocationGenericTarget.ActionStaticGenericData.Should().Be($"JamesBond_False");
+        }
+
         public static IEnumerable<object[]> ActionWrongGenericInfoData() =>
             new List<object[]>
             {
@@ -87,30 +109,18 @@ namespace FastAndFaster.Tests
                         GenericTypeIndex = new[] { 1 },
                         GenericType = new[] { typeof(double), typeof(byte), typeof(bool) }
                     }
+                },
+                // Wrong concrete type
+                new object[]
+                {
+                    new[] { typeof(bool), typeof(bool) },
+                    new GenericInfo
+                    {
+                        GenericTypeIndex = new[] { 1 },
+                        GenericType = new[] { typeof(bool), typeof(int) }
+                    }
                 }
             };
-
-        [Fact]
-        public void ShouldCallStaticGenericAction()
-        {
-            // Arrange
-            var typeName = typeof(InvocationGenericTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationGenericTarget.ActionStaticGeneric);
-            var argumentTypes = new[] { typeof(string), typeof(bool) };
-            var arguments = new object[] { "JamesBond", false };
-            var genericInfo = new GenericInfo
-            {
-                GenericTypeIndex = new[] { 0, 1 },
-                GenericType = new[] { typeof(string), typeof(bool) }
-            };
-            var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes, genericInfo);
-
-            // Action
-            invocator(null, arguments);
-
-            // Assert
-            InvocationGenericTarget.ActionStaticGenericData.Should().Be($"JamesBond_False");
-        }
 
         [Theory]
         [MemberData(nameof(ActionWrongGenericInfoData))]
@@ -228,7 +238,7 @@ namespace FastAndFaster.Tests
                 // Wrong generic type index
                 new object[]
                 {
-                    new[] {  typeof(int), typeof(string)  },
+                    new[] {  typeof(int), typeof(string) },
                     new GenericInfo
                     {
                         GenericTypeIndex = new[] { 0 },
@@ -255,6 +265,16 @@ namespace FastAndFaster.Tests
                         GenericType = new[] { typeof(string), typeof(bool), typeof(float) }
                     },
                 },
+                // Wrong concrete type
+                new object[]
+                {
+                    new[] { typeof(bool), typeof(string) },
+                    new GenericInfo
+                    {
+                        GenericTypeIndex = new[] { 1 },
+                        GenericType = new[] { typeof(string), typeof(bool) }
+                    }
+                }
             };
 
         [Theory]
@@ -263,7 +283,7 @@ namespace FastAndFaster.Tests
         {
             // Arrange
             var typeName = typeof(InvocationGenericTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationGenericTarget.FuncReturnGeneric);
+            var methodName = nameof(InvocationGenericTarget.FuncGenericArguments);
 
             // Act
             Func<object> action = () => Invocator.CreateFunc(typeName, methodName, argumentTypes, genericInfo);

--- a/FastAndFaster.Tests/InvocatorTests.cs
+++ b/FastAndFaster.Tests/InvocatorTests.cs
@@ -240,7 +240,7 @@ namespace FastAndFaster.Tests
         }
 
         [Fact]
-        public void CallVirtualAction()
+        public void ShouldCallAction_Virtual()
         {
             // Arrange
             var target = new ChildInvocationTarget();
@@ -293,6 +293,44 @@ namespace FastAndFaster.Tests
 
             // Act
             var rs = invocator(target, null);
+
+            // Assert
+            rs.Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public void ShouldCallAction_Abstract()
+        {
+            // Arrange
+            var target = new InvocationConcreteTarget();
+            var typeName = typeof(InvocationAbstractTarget).AssemblyQualifiedName;
+            var methodName = nameof(InvocationAbstractTarget.ActionMultipleParams);
+            var parameterTypes = new[] { typeof(string), typeof(int) };
+            var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
+            var arguments = new object[] { "Duong", 17 };
+            var expectedResult = 22;
+
+            // Act
+            invocator(target, arguments);
+
+            // Assert
+            target.ActionMultipleParamsCalled.Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public void ShouldCallFunc_Abstract()
+        {
+            // Arrange
+            InvocationAbstractTarget target = new InvocationConcreteTarget();
+            var typeName = typeof(InvocationAbstractTarget).AssemblyQualifiedName;
+            var methodName = nameof(InvocationAbstractTarget.FuncMultipleParams);
+            var parameterTypes = new[] { typeof(string), typeof(int) };
+            var invocator = Invocator.CreateFunc(typeName, methodName, parameterTypes);
+            var arguments = new object[] { "Duong", 17 };
+            var expectedResult = "Duong:17";
+
+            // Act
+            var rs = invocator(target, arguments);
 
             // Assert
             rs.Should().Be(expectedResult);

--- a/FastAndFaster/Helpers/IlHelper.cs
+++ b/FastAndFaster/Helpers/IlHelper.cs
@@ -37,9 +37,10 @@ namespace FastAndFaster.Helpers
             il.Emit(OpCodes.Ret);
         }
 
-        internal static void ExecuteMethod(ILGenerator il, MethodInfo methodInfo, bool isVirtual)
+        internal static void ExecuteMethod(ILGenerator il, MethodInfo methodInfo)
         {
-            var callOpCode = isVirtual ? OpCodes.Callvirt : OpCodes.Call;
+            var needVirtualCall = methodInfo.IsAbstract || methodInfo.IsVirtual;
+            var callOpCode = needVirtualCall ? OpCodes.Callvirt : OpCodes.Call;
             il.EmitCall(callOpCode, methodInfo, null);
 
             if (methodInfo.ReturnType != typeof(void) && methodInfo.ReturnType.IsValueType)

--- a/FastAndFaster/Invocator.cs
+++ b/FastAndFaster/Invocator.cs
@@ -124,13 +124,13 @@ namespace FastAndFaster
                 // Moreover, a static method cannot be abstract nor virtual.
                 // Because of that, we can emit OpCode "Call" instead of "Callvirt" 
                 IlHelper.LoadArguments(il, METHOD_LOAD_INDEX, parameterTypes);
-                IlHelper.ExecuteMethod(il, methodInfo, false);
+                IlHelper.ExecuteMethod(il, methodInfo);
             }
             else
             {
                 IlHelper.LoadTarget(il, type);
                 IlHelper.LoadArguments(il, METHOD_LOAD_INDEX, parameterTypes);
-                IlHelper.ExecuteMethod(il, methodInfo, true);
+                IlHelper.ExecuteMethod(il, methodInfo);
             }
         }
     }

--- a/FastAndFaster/Invocator.cs
+++ b/FastAndFaster/Invocator.cs
@@ -117,21 +117,14 @@ namespace FastAndFaster
         {
             var il = dynInvoc.GetILGenerator();
 
-            if (methodInfo.IsStatic)
+            if (!methodInfo.IsStatic)
             {
-                // For a static method, there is no class instance to load to the stack.
-                // We can skip calling LoadTarget.
-                // Moreover, a static method cannot be abstract nor virtual.
-                // Because of that, we can emit OpCode "Call" instead of "Callvirt" 
-                IlHelper.LoadArguments(il, METHOD_LOAD_INDEX, parameterTypes);
-                IlHelper.ExecuteMethod(il, methodInfo);
-            }
-            else
-            {
+                // We only need to load the class instance to the stack if the method is non-static.
                 IlHelper.LoadTarget(il, type);
-                IlHelper.LoadArguments(il, METHOD_LOAD_INDEX, parameterTypes);
-                IlHelper.ExecuteMethod(il, methodInfo);
             }
+
+            IlHelper.LoadArguments(il, METHOD_LOAD_INDEX, parameterTypes);
+            IlHelper.ExecuteMethod(il, methodInfo);
         }
     }
 }


### PR DESCRIPTION
Improve logic to check if `call` can be used instead of `callvirt`.
Fix a bug in unit test