### PR TITLE
Switch library to netstandard2.1

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK 3.1
+      - name: Setup .NET 6 SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/FastAndFaster.Benchmark/FastAndFaster.Benchmark.csproj
+++ b/FastAndFaster.Benchmark/FastAndFaster.Benchmark.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastAndFaster.Benchmark/Program.cs
+++ b/FastAndFaster.Benchmark/Program.cs
@@ -1,180 +1,172 @@
-﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
-using FastAndFaster.Tests.DummyClasses;
-using System;
+﻿using System;
 using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using FastAndFaster;
+using FastAndFaster.Tests.DummyClasses;
 
-namespace FastAndFaster.Benchmark
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+[MemoryDiagnoser]
+public class TestCreatorRunner
 {
-    class Program
+    private Type _type;
+    private string _typeName;
+    Func<object[], object> _delegate;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        static void Main(string[] args)
-        {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-        }
+        _type = typeof(MultipleConstructors);
+        _typeName = _type.AssemblyQualifiedName;
+        _delegate = Initializer.Create(_typeName);
     }
 
-    [MemoryDiagnoser]
-    public class TestCreatorRunner
+    [Benchmark]
+    public object Reflection_CreateInstance() => Activator.CreateInstance(_type);
+
+    [Benchmark]
+    public object DynamicGenerator_CreateInstance() => _delegate(null);
+
+    [Benchmark]
+    public object Static_CreateInstance() => new MultipleConstructors();
+}
+
+public class AbstractTestMethodRunner
+{
+    protected Type _type;
+    protected string _typeName;
+    protected InvocationTarget _target;
+    protected string _methodName;
+    protected MethodInfo _methodInfo;
+    protected Type[] _argumentTypes;
+    protected object[] _arguments;
+
+    public virtual void Setup()
     {
-        private Type _type;
-        private string _typeName;
-        Func<object[], object> _delegate;
+        _type = typeof(InvocationTarget);
+        _typeName = _type.AssemblyQualifiedName;
+        _target = new InvocationTarget();
+    }
+}
 
-        [GlobalSetup]
-        public void Setup()
-        {
-            _type = typeof(MultipleConstructors);
-            _typeName = _type.AssemblyQualifiedName;
-            _delegate = Initializer.Create(_typeName);
-        }
+[MemoryDiagnoser]
+public class TestActionRunner : AbstractTestMethodRunner
+{
+    private Action<object, object[]> _delegate;
 
-        [Benchmark]
-        public object Reflection_CreateInstance() => Activator.CreateInstance(_type);
-
-        [Benchmark]
-        public object DynamicGenerator_CreateInstance() => _delegate(null);
-
-        [Benchmark]
-        public object Static_CreateInstance() => new MultipleConstructors();
+    [GlobalSetup]
+    public override void Setup()
+    {
+        base.Setup();
+        _methodName = nameof(InvocationTarget.Action);
+        _methodInfo = _type.GetMethod(_methodName);
+        _argumentTypes = new[] { typeof(string), typeof(int) };
+        _arguments = new object[] { "Duong", 32 };
+        _delegate = Invocator.CreateAction(_typeName, _methodName, _argumentTypes);
     }
 
-    public class AbstractTestMethodRunner
-    {
-        protected Type _type;
-        protected string _typeName;
-        protected InvocationTarget _target;
-        protected string _methodName;
-        protected MethodInfo _methodInfo;
-        protected Type[] _argumentTypes;
-        protected object[] _arguments;
+    [Benchmark]
+    public void Reflection_CallAction() => _methodInfo.Invoke(_target, _arguments);
 
-        public virtual void Setup()
-        {
-            _type = typeof(InvocationTarget);
-            _typeName = _type.AssemblyQualifiedName;
-            _target = new InvocationTarget();
-        }
+    [Benchmark]
+    public void DynamicGenerator_CallAction() => _delegate(_target, _arguments);
+
+    [Benchmark]
+    public void Static_CallAction() => _target.Action("Duong", 32);
+}
+
+
+[MemoryDiagnoser]
+public class TestFuncRunner : AbstractTestMethodRunner
+{
+    private Func<object, object[], object> _delegate;
+
+    [GlobalSetup]
+    public override void Setup()
+    {
+        base.Setup();
+        _methodName = nameof(InvocationTarget.FuncHandleVal);
+        _methodInfo = _type.GetMethod(_methodName);
+        _argumentTypes = new[] { typeof(int), typeof(int) };
+        _arguments = new object[] { 17, 10 };
+        _delegate = Invocator.CreateFunc(_typeName, _methodName, _argumentTypes);
     }
 
-    [MemoryDiagnoser]
-    public class TestActionRunner : AbstractTestMethodRunner
+    [Benchmark]
+    public object Reflection_CallFunc() => _methodInfo.Invoke(_target, _arguments);
+
+    [Benchmark]
+    public object DynamicGenerator_CallFunc() => _delegate(_target, _arguments);
+
+    [Benchmark]
+    public object Static_CallFunc() => _target.FuncHandleVal(17, 10);
+}
+
+public class AbstractTestStaticMethodRunner
+{
+    protected Type _type;
+    protected string _typeName;
+    protected string _methodName;
+    protected MethodInfo _methodInfo;
+    protected Type[] _argumentTypes;
+    protected object[] _arguments;
+
+    public virtual void Setup()
     {
-        private Action<object, object[]> _delegate;
+        _type = typeof(InvocationStaticTarget);
+        _typeName = _type.AssemblyQualifiedName;
+    }
+}
 
-        [GlobalSetup]
-        public override void Setup()
-        {
-            base.Setup();
-            _methodName = nameof(InvocationTarget.Action);
-            _methodInfo = _type.GetMethod(_methodName);
-            _argumentTypes = new[] { typeof(string), typeof(int) };
-            _arguments = new object[] { "Duong", 32 };
-            _delegate = Invocator.CreateAction(_typeName, _methodName, _argumentTypes);
-        }
+[MemoryDiagnoser]
+public class TestStaticActionRunner : AbstractTestStaticMethodRunner
+{
+    private Action<object, object[]> _delegate;
 
-        [Benchmark]
-        public void Reflection_CallAction() => _methodInfo.Invoke(_target, _arguments);
-
-        [Benchmark]
-        public void DynamicGenerator_CallAction() => _delegate(_target, _arguments);
-
-        [Benchmark]
-        public void Static_CallAction() => _target.Action("Duong", 32);
+    [GlobalSetup]
+    public override void Setup()
+    {
+        base.Setup();
+        _methodName = nameof(InvocationStaticTarget.ActionHandleVal);
+        _methodInfo = _type.GetMethod(_methodName);
+        _argumentTypes = new[] { typeof(int), typeof(int) };
+        _arguments = new object[] { 17, 10 };
+        _delegate = Invocator.CreateAction(_typeName, _methodName, _argumentTypes);
     }
 
+    [Benchmark]
+    public void Reflection_CallStaticAction() => _methodInfo.Invoke(null, _arguments);
 
-    [MemoryDiagnoser]
-    public class TestFuncRunner : AbstractTestMethodRunner
+    [Benchmark]
+    public void DynamicGenerator_CallStaticAction() => _delegate(null, _arguments);
+
+    [Benchmark]
+    public void Static_CallStaticAction() => InvocationStaticTarget.ActionHandleVal(17, 10);
+}
+
+[MemoryDiagnoser]
+public class TestStaticFuncRunner : AbstractTestStaticMethodRunner
+{
+    private Func<object, object[], object> _delegate;
+
+    [GlobalSetup]
+    public override void Setup()
     {
-        private Func<object, object[], object> _delegate;
-
-        [GlobalSetup]
-        public override void Setup()
-        {
-            base.Setup();
-            _methodName = nameof(InvocationTarget.FuncHandleVal);
-            _methodInfo = _type.GetMethod(_methodName);
-            _argumentTypes = new[] { typeof(int), typeof(int) };
-            _arguments = new object[] { 17, 10 };
-            _delegate = Invocator.CreateFunc(_typeName, _methodName, _argumentTypes);
-        }
-
-        [Benchmark]
-        public object Reflection_CallFunc() => _methodInfo.Invoke(_target, _arguments);
-
-        [Benchmark]
-        public object DynamicGenerator_CallFunc() => _delegate(_target, _arguments);
-
-        [Benchmark]
-        public object Static_CallFunc() => _target.FuncHandleVal(17, 10);
+        base.Setup();
+        _methodName = nameof(InvocationStaticTarget.FuncHandleVal);
+        _methodInfo = _type.GetMethod(_methodName);
+        _argumentTypes = new[] { typeof(int), typeof(int) };
+        _arguments = new object[] { 17, 10 };
+        _delegate = Invocator.CreateFunc(_typeName, _methodName, _argumentTypes);
     }
 
-    public class AbstractTestStaticMethodRunner
-    {
-        protected Type _type;
-        protected string _typeName;
-        protected string _methodName;
-        protected MethodInfo _methodInfo;
-        protected Type[] _argumentTypes;
-        protected object[] _arguments;
+    [Benchmark]
+    public object Reflection_CallStaticFunc() => _methodInfo.Invoke(null, _arguments);
 
-        public virtual void Setup()
-        {
-            _type = typeof(InvocationStaticTarget);
-            _typeName = _type.AssemblyQualifiedName;
-        }
-    }
+    [Benchmark]
+    public object DynamicGenerator_CallStaticFunc() => _delegate(null, _arguments);
 
-    [MemoryDiagnoser]
-    public class TestStaticActionRunner : AbstractTestStaticMethodRunner
-    {
-        private Action<object, object[]> _delegate;
-
-        [GlobalSetup]
-        public override void Setup()
-        {
-            base.Setup();
-            _methodName = nameof(InvocationStaticTarget.ActionHandleVal);
-            _methodInfo = _type.GetMethod(_methodName);
-            _argumentTypes = new[] { typeof(int), typeof(int) };
-            _arguments = new object[] { 17, 10 };
-            _delegate = Invocator.CreateAction(_typeName, _methodName, _argumentTypes);
-        }
-
-        [Benchmark]
-        public void Reflection_CallStaticAction() => _methodInfo.Invoke(null, _arguments);
-
-        [Benchmark]
-        public void DynamicGenerator_CallStaticAction() => _delegate(null, _arguments);
-
-        [Benchmark]
-        public void Static_CallStaticAction() => InvocationStaticTarget.ActionHandleVal(17, 10);
-    }
-
-    [MemoryDiagnoser]
-    public class TestStaticFuncRunner : AbstractTestStaticMethodRunner
-    {
-        private Func<object, object[], object> _delegate;
-
-        [GlobalSetup]
-        public override void Setup()
-        {
-            base.Setup();
-            _methodName = nameof(InvocationStaticTarget.FuncHandleVal);
-            _methodInfo = _type.GetMethod(_methodName);
-            _argumentTypes = new[] { typeof(int), typeof(int) };
-            _arguments = new object[] { 17, 10 };
-            _delegate = Invocator.CreateFunc(_typeName, _methodName, _argumentTypes);
-        }
-
-        [Benchmark]
-        public object Reflection_CallStaticFunc() => _methodInfo.Invoke(null, _arguments);
-
-        [Benchmark]
-        public object DynamicGenerator_CallStaticFunc() => _delegate(null, _arguments);
-
-        [Benchmark]
-        public object Static_CallStaticFunc() => InvocationStaticTarget.FuncHandleVal(17, 10);
-    }
+    [Benchmark]
+    public object Static_CallStaticFunc() => InvocationStaticTarget.FuncHandleVal(17, 10);
 }

--- a/FastAndFaster.Tests/DummyClasses/InvocationGenericTarget.cs
+++ b/FastAndFaster.Tests/DummyClasses/InvocationGenericTarget.cs
@@ -1,52 +1,49 @@
-﻿using System.Collections.Generic;
+﻿namespace FastAndFaster.Tests.DummyClasses;
 
-namespace FastAndFaster.Tests.DummyClasses
+public interface IPerson
 {
-    public interface IPerson
+    public List<string> Skills { get; set; }
+}
+
+public class Person : IPerson
+{
+    public List<string> Skills { get; set; } = new List<string>();
+}
+
+public class InvocationGenericTarget
+{
+    public string ActionGenericArgumentsData { get; private set; }
+
+    public static string ActionStaticGenericData { get; private set; }
+
+    public void ActionGenericArguments<T>(int i, T input)
     {
-        public List<string> Skills { get; set; }
     }
 
-    public class Person : IPerson
+    public void ActionGenericArguments<T1, T2>(string s, T1 input) =>
+        ActionGenericArgumentsData = $"{s}_{input}_{default(T2)}";
+
+    public static void ActionStaticGeneric<T1, T2>(T1 input1, T2 input2) =>
+        ActionStaticGenericData = $"{input1}_{input2}";
+
+    public T FuncGenericArguments<T>(int i, T input) => input;
+
+    public string FuncGenericArguments<T1, T2>(int i, T1 input) => $"{i}:{input}_{default(T2)}";
+
+    public T FuncReturnGeneric<T>(IEnumerable<string> skills)
+        where T : IPerson, new()
     {
-        public List<string> Skills { get; set; } = new List<string>();
-    }
-
-    public class InvocationGenericTarget
-    {
-        public string ActionGenericArgumentsData { get; private set; }
-
-        public static string ActionStaticGenericData { get; private set; }
-
-        public void ActionGenericArguments<T>(int i, T input)
+        var rs = new T();
+        foreach (var skill in skills)
         {
+            rs.Skills.Add(skill);
         }
-
-        public void ActionGenericArguments<T1, T2>(string s, T1 input) =>
-            ActionGenericArgumentsData = $"{s}_{input}_{default(T2)}";
-
-        public static void ActionStaticGeneric<T1, T2>(T1 input1, T2 input2) =>
-            ActionStaticGenericData = $"{input1}_{input2}";
-
-        public T FuncGenericArguments<T>(int i, T input) => input;
-
-        public string FuncGenericArguments<T1, T2>(int i, T1 input) => $"{i}:{input}_{default(T2)}";
-
-        public T FuncReturnGeneric<T>(IEnumerable<string> skills)
-            where T : IPerson, new()
-        {
-            var rs = new T();
-            foreach (var skill in skills)
-            {
-                rs.Skills.Add(skill);
-            }
-            return rs;
-        }
-
-        public static T1 FuncStaticGeneric<T1, T2>(T2 input)
-            where T1 : IPerson, new() => new T1
-            {
-                Skills = new List<string> { input.ToString() }
-            };
+        return rs;
     }
+
+    public static T1 FuncStaticGeneric<T1, T2>(T2 input)
+        where T1 : IPerson, new() => new T1
+        {
+            Skills = new List<string> { input.ToString() }
+        };
 }

--- a/FastAndFaster.Tests/DummyClasses/InvocationStaticTarget.cs
+++ b/FastAndFaster.Tests/DummyClasses/InvocationStaticTarget.cs
@@ -1,45 +1,41 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿namespace FastAndFaster.Tests.DummyClasses;
 
-namespace FastAndFaster.Tests.DummyClasses
+public static class InvocationStaticTarget
 {
-    public static class InvocationStaticTarget
-    {
-        public static bool ActionParameterlessCalled { get; set; }
+    public static bool ActionParameterlessCalled { get; set; }
 
-        public static int ActionHandleValData { get; set; }
+    public static int ActionHandleValData { get; set; }
 
-        public static List<string> ActionHandleRefData { get; set; }
+    public static List<string> ActionHandleRefData { get; set; }
 
-        public static int FuncParameterlessData { get; set; } = 1989;
+    public static int FuncParameterlessData { get; set; } = 1989;
 
-        public static int InterfaceTestData { get; private set; }
+    public static int InterfaceTestData { get; private set; }
 
-        public static void ActionParameterless() => ActionParameterlessCalled = true;
+    public static void ActionParameterless() => ActionParameterlessCalled = true;
 
-        public static void ActionHandleVal(int first, int second) => ActionHandleValData = first + second;
+    public static void ActionHandleVal(int first, int second) => ActionHandleValData = first + second;
 
-        public static void ActionHandleRef(List<string> names, string name) =>
-            ActionHandleRefData = new List<string>(names)
-            {
-                name
-            };
-
-        public static int FuncParameterless() => FuncParameterlessData;
-
-        public static int FuncHandleVal(int first, int second) => first + second;
-
-        public static List<string> FuncHandleRef(List<string> names, string name)
+    public static void ActionHandleRef(List<string> names, string name) =>
+        ActionHandleRefData = new List<string>(names)
         {
-            var newList = new List<string>(names)
-            {
-                name
-            };
-            return newList;
-        }
+            name
+        };
 
-        public static int FuncWithInterface(IEnumerable<string> names) => names.Count();
+    public static int FuncParameterless() => FuncParameterlessData;
 
-        public static void ActionWithInterface(IEnumerable<int> ages) => InterfaceTestData = ages.Count();
+    public static int FuncHandleVal(int first, int second) => first + second;
+
+    public static List<string> FuncHandleRef(List<string> names, string name)
+    {
+        var newList = new List<string>(names)
+        {
+            name
+        };
+        return newList;
     }
+
+    public static int FuncWithInterface(IEnumerable<string> names) => names.Count();
+
+    public static void ActionWithInterface(IEnumerable<int> ages) => InterfaceTestData = ages.Count();
 }

--- a/FastAndFaster.Tests/DummyClasses/InvocationTarget.cs
+++ b/FastAndFaster.Tests/DummyClasses/InvocationTarget.cs
@@ -1,86 +1,81 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace FastAndFaster.Tests.DummyClasses;
 
-namespace FastAndFaster.Tests.DummyClasses
+public interface IInvocationTarget
 {
-    public interface IInvocationTarget
+    void Action(string name, int age);
+
+    int FuncHandleVal(int first, int second);
+
+    IEnumerable<string> FuncHandleRef(List<string> names, string name);
+}
+
+public class InvocationTarget : IInvocationTarget
+{
+    public int ParameterlessFuncReturnValData { get; set; }
+
+    public string ParameterlessFuncReturnRefData { get; set; }
+
+    public bool ParameterlessActionCalled { get; private set; } = false;
+
+    public bool VirtualActionCalled { get; private set; } = false;
+
+    public string VirtualFuncData { get; set; }
+
+    public (string, int) ActionData { get; private set; }
+
+    public bool OverloadActionCalled { get; private set; }
+
+    public int ParameterlessFuncReturnVal() => ParameterlessFuncReturnValData;
+
+    public string ParameterlessFuncReturnRef()
     {
-        void Action(string name, int age);
-
-        int FuncHandleVal(int first, int second);
-
-        IEnumerable<string> FuncHandleRef(List<string> names, string name);
+        var dummy = "dummy";
+        return ParameterlessFuncReturnRefData;
     }
 
-    public class InvocationTarget : IInvocationTarget
+    public void ParameterlessAction() => ParameterlessActionCalled = true;
+
+    public void Action(string name, int age) => ActionData = (name, age);
+
+    public IEnumerable<string> FuncHandleRef(List<string> names, string name)
     {
-        public int ParameterlessFuncReturnValData { get; set; }
-
-        public string ParameterlessFuncReturnRefData { get; set; }
-
-        public bool ParameterlessActionCalled { get; private set; } = false;
-
-        public bool VirtualActionCalled { get; private set; } = false;
-
-        public string VirtualFuncData { get; set; }
-
-        public (string, int) ActionData { get; private set; }
-
-        public bool OverloadActionCalled { get; private set; }
-
-        public int ParameterlessFuncReturnVal() => ParameterlessFuncReturnValData;
-
-        public string ParameterlessFuncReturnRef()
+        var newList = new List<string>(names)
         {
-            var dummy = "dummy";
-            return ParameterlessFuncReturnRefData;
-        }
-
-        public void ParameterlessAction() => ParameterlessActionCalled = true;
-
-        public void Action(string name, int age) => ActionData = (name, age);
-
-        public IEnumerable<string> FuncHandleRef(List<string> names, string name)
-        {
-            var newList = new List<string>(names)
-            {
-                name
-            };
-            return newList;
-        }
-
-        public int FuncHandleVal(int first, int second) => first + second;
-
-        public virtual void VirtualAction(int dummy1, int dummy2) => VirtualActionCalled = true;
-
-        public virtual string VirtualFunc() => VirtualFuncData;
-
-        public void OverloadAction() => OverloadActionCalled = true;
-
-        public void OverloadAction(string dummy) => throw new Exception("Called the wrong overload");
-
-        public string OverloadFunc(string s) => s;
-
-        public int OverloadFunc(int first, int second) => first + second;
-
-        public int InterfaceInput(IEnumerable<string> names) => names.Count();
-
-        public IEnumerable<int> InterfaceOutput(int n) => Enumerable.Range(0, n);
-
-        private void PrivateAction(string s, int i) => throw new Exception("Should not be called");
-
-        private int PrivateFunc() => throw new Exception("Should not be called");
+            name
+        };
+        return newList;
     }
 
-    public class ChildInvocationTarget : InvocationTarget
-    {
-        public bool ChildVirtualActionCalled { get; private set; } = false;
+    public int FuncHandleVal(int first, int second) => first + second;
 
-        public string ChildVirtualFuncData { get; set; }
+    public virtual void VirtualAction(int dummy1, int dummy2) => VirtualActionCalled = true;
 
-        public override void VirtualAction(int dummy1, int dummy2) => ChildVirtualActionCalled = true;
+    public virtual string VirtualFunc() => VirtualFuncData;
 
-        public override string VirtualFunc() => ChildVirtualFuncData;
-    }
+    public void OverloadAction() => OverloadActionCalled = true;
+
+    public void OverloadAction(string dummy) => throw new Exception("Called the wrong overload");
+
+    public string OverloadFunc(string s) => s;
+
+    public int OverloadFunc(int first, int second) => first + second;
+
+    public int InterfaceInput(IEnumerable<string> names) => names.Count();
+
+    public IEnumerable<int> InterfaceOutput(int n) => Enumerable.Range(0, n);
+
+    private void PrivateAction(string s, int i) => throw new Exception("Should not be called");
+
+    private int PrivateFunc() => throw new Exception("Should not be called");
+}
+
+public class ChildInvocationTarget : InvocationTarget
+{
+    public bool ChildVirtualActionCalled { get; private set; } = false;
+
+    public string ChildVirtualFuncData { get; set; }
+
+    public override void VirtualAction(int dummy1, int dummy2) => ChildVirtualActionCalled = true;
+
+    public override string VirtualFunc() => ChildVirtualFuncData;
 }

--- a/FastAndFaster.Tests/DummyClasses/MultipleConstructors.cs
+++ b/FastAndFaster.Tests/DummyClasses/MultipleConstructors.cs
@@ -1,29 +1,26 @@
-﻿using System.Collections.Generic;
+﻿namespace FastAndFaster.Tests.DummyClasses;
 
-namespace FastAndFaster.Tests.DummyClasses
+public class MultipleConstructors
 {
-    public class MultipleConstructors
+    public int Age { get; private set; }
+
+    public string Name { get; private set; }
+
+    public List<bool> Bools { get; private set; }
+
+    public MultipleConstructors()
     {
-        public int Age { get; private set; }
+    }
 
-        public string Name { get; private set; }
+    public MultipleConstructors(int age, string name, List<bool> bools)
+    {
+        Age = age;
+        Name = name;
+        Bools = bools;
+    }
 
-        public List<bool> Bools { get; private set; }
-
-        public MultipleConstructors()
-        {
-        }
-
-        public MultipleConstructors(int age, string name, List<bool> bools)
-        {
-            Age = age;
-            Name = name;
-            Bools = bools;
-        }
-
-        protected MultipleConstructors(int age)
-        {
-            Age = age;
-        }
+    protected MultipleConstructors(int age)
+    {
+        Age = age;
     }
 }

--- a/FastAndFaster.Tests/EndToEndTests.cs
+++ b/FastAndFaster.Tests/EndToEndTests.cs
@@ -1,29 +1,24 @@
-﻿using FastAndFaster.Tests.DummyClasses;
-using FluentAssertions;
-using Xunit;
+﻿namespace FastAndFaster.Tests;
 
-namespace FastAndFaster.Tests
+public class EndToEndTests
 {
-    public class EndToEndTests
+    [Fact]
+    public void ShouldCreateInstanceAndCallMethod()
     {
-        [Fact]
-        public void ShouldCreateInstanceAndCallMethod()
-        {
-            // Arrange, Act
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationTarget.Action);
-            var argumentTypes = new[] { typeof(string), typeof(int) };
-            var arguments = new object[] { "DuongNT", 1989 };
-            var initializer = Initializer.Create(typeName);
-            var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes);
+        // Arrange, Act
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationTarget.Action);
+        var argumentTypes = new[] { typeof(string), typeof(int) };
+        var arguments = new object[] { "DuongNT", 1989 };
+        var initializer = Initializer.Create(typeName);
+        var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes);
 
-            // Act
-            var target = initializer(null) as InvocationTarget;
-            invocator(target, arguments);
+        // Act
+        var target = initializer(null) as InvocationTarget;
+        invocator(target, arguments);
 
-            // Assert
-            target.Should().NotBeNull();
-            target.ActionData.Should().Be(("DuongNT", 1989));
-        }
+        // Assert
+        target.Should().NotBeNull();
+        target.ActionData.Should().Be(("DuongNT", 1989));
     }
 }

--- a/FastAndFaster.Tests/FastAndFaster.Tests.csproj
+++ b/FastAndFaster.Tests/FastAndFaster.Tests.csproj
@@ -2,17 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\FastAndFaster\FastAndFaster.csproj" />
   </ItemGroup>
-	
+
+  <ItemGroup>
+    <None Remove="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
 </Project>

--- a/FastAndFaster.Tests/GlobalUsings.cs
+++ b/FastAndFaster.Tests/GlobalUsings.cs
@@ -1,0 +1,7 @@
+﻿global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using FastAndFaster.Helpers;
+global using FastAndFaster.Tests.DummyClasses;
+global using FluentAssertions;
+global using Xunit;

--- a/FastAndFaster.Tests/InitializerTests.cs
+++ b/FastAndFaster.Tests/InitializerTests.cs
@@ -1,108 +1,101 @@
-﻿using FastAndFaster.Tests.DummyClasses;
-using FluentAssertions;
-using System;
-using System.Collections.Generic;
-using Xunit;
+﻿namespace FastAndFaster.Tests;
 
-namespace FastAndFaster.Tests
+public class InitializerTests
 {
-    public class InitializerTests
+    [Fact]
+    public void ShouldCreateObject_ParameterlessConstructor()
     {
-        [Fact]
-        public void ShouldCreateObject_ParameterlessConstructor()
-        {
-            // Arrange
-            var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
-            var initializer = Initializer.Create(assemblyQualifiedName);
+        // Arrange
+        var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
+        var initializer = Initializer.Create(assemblyQualifiedName);
 
-            // Act
-            var cls = initializer(null) as MultipleConstructors;
+        // Act
+        var cls = initializer(null) as MultipleConstructors;
 
-            // Assert
-            cls.Should().NotBeNull();
-        }
+        // Assert
+        cls.Should().NotBeNull();
+    }
 
-        [Fact]
-        public void ShouldCreateObject_ConstructorWithParameter()
-        {
-            // Arrange
-            var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
-            var argumentTypes = new[] { typeof(int), typeof(string), typeof(List<bool>) };
-            var age = 32;
-            var name = "Duong";
-            var bools = new List<bool> { true, false, false, true };
-            var arguments = new object[] { age, name, bools };
-            var initializer = Initializer.Create(assemblyQualifiedName, argumentTypes);
+    [Fact]
+    public void ShouldCreateObject_ConstructorWithParameter()
+    {
+        // Arrange
+        var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
+        var argumentTypes = new[] { typeof(int), typeof(string), typeof(List<bool>) };
+        var age = 32;
+        var name = "Duong";
+        var bools = new List<bool> { true, false, false, true };
+        var arguments = new object[] { age, name, bools };
+        var initializer = Initializer.Create(assemblyQualifiedName, argumentTypes);
 
-            // Act
-            var cls = initializer(arguments) as MultipleConstructors;
+        // Act
+        var cls = initializer(arguments) as MultipleConstructors;
 
-            // Assert
-            cls.Should().NotBeNull();
-            cls.Age.Should().Be(age);
-            cls.Name.Should().Be(name);
-            cls.Bools.Should().BeSameAs(bools);
-        }
+        // Assert
+        cls.Should().NotBeNull();
+        cls.Age.Should().Be(age);
+        cls.Name.Should().Be(name);
+        cls.Bools.Should().BeSameAs(bools);
+    }
 
-        [Fact]
-        public void ShouldCreateIndividualObjects()
-        {
-            // Arrange
-            var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
-            var initializer = Initializer.Create(assemblyQualifiedName);
+    [Fact]
+    public void ShouldCreateIndividualObjects()
+    {
+        // Arrange
+        var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
+        var initializer = Initializer.Create(assemblyQualifiedName);
 
-            // Act
-            var cls1 = initializer(null) as MultipleConstructors;
-            var cls2 = initializer(null) as MultipleConstructors;
+        // Act
+        var cls1 = initializer(null) as MultipleConstructors;
+        var cls2 = initializer(null) as MultipleConstructors;
 
-            // Assert
-            cls1.Should().NotBeNull();
-            cls2.Should().NotBeNull();
-            cls1.Should().NotBe(cls2);
-        }
+        // Assert
+        cls1.Should().NotBeNull();
+        cls2.Should().NotBeNull();
+        cls1.Should().NotBe(cls2);
+    }
 
-        [Fact]
-        public void ShouldThrowException_TypeNameNotFound()
-        {
-            // Act
-            var fakeName = "FastAndFaster.Tests.DummyClasses.FakeFake, " +
-                "FastAndFaster.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+    [Fact]
+    public void ShouldThrowException_TypeNameNotFound()
+    {
+        // Act
+        var fakeName = "FastAndFaster.Tests.DummyClasses.FakeFake, " +
+            "FastAndFaster.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
 
-            // Arrange
-            Func<object> action = () => Initializer.Create(fakeName);
+        // Arrange
+        Func<object> action = () => Initializer.Create(fakeName);
 
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find any class with Assembly Qualified Name: {fakeName}");
-        }
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find any class with Assembly Qualified Name: {fakeName}");
+    }
 
-        [Fact]
-        public void ShouldThrowException_WrongConstructorSignature()
-        {
-            // Arrange
-            var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
+    [Fact]
+    public void ShouldThrowException_WrongConstructorSignature()
+    {
+        // Arrange
+        var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
 
-            // Act
-            Func<object> action = () => Initializer.Create(assemblyQualifiedName, new[] { typeof(string) });
+        // Act
+        Func<object> action = () => Initializer.Create(assemblyQualifiedName, new[] { typeof(string) });
 
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find constructor with given signature for class: {assemblyQualifiedName}");
-        }
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find constructor with given signature for class: {assemblyQualifiedName}");
+    }
 
-        [Fact]
-        public void ShouldThrowException_NonVisibleConstructor()
-        {
-            // Arrange
-            var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
-            var argumentTypes = new[] { typeof(int) };
+    [Fact]
+    public void ShouldThrowException_NonVisibleConstructor()
+    {
+        // Arrange
+        var assemblyQualifiedName = typeof(MultipleConstructors).AssemblyQualifiedName;
+        var argumentTypes = new[] { typeof(int) };
 
-            // Act
-            Func<object> action = () => Initializer.Create(assemblyQualifiedName, argumentTypes);
+        // Act
+        Func<object> action = () => Initializer.Create(assemblyQualifiedName, argumentTypes);
 
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find constructor with given signature for class: {assemblyQualifiedName}");
-        }
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find constructor with given signature for class: {assemblyQualifiedName}");
     }
 }

--- a/FastAndFaster.Tests/InvocatorGenericTests.cs
+++ b/FastAndFaster.Tests/InvocatorGenericTests.cs
@@ -1,12 +1,4 @@
-﻿using FastAndFaster.Helpers;
-using FastAndFaster.Tests.DummyClasses;
-using FluentAssertions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Xunit;
-
-namespace FastAndFaster.Tests
+﻿namespace FastAndFaster.Tests
 {
     public class InvocatorGenericTests
     {

--- a/FastAndFaster.Tests/InvocatorStaticTests.cs
+++ b/FastAndFaster.Tests/InvocatorStaticTests.cs
@@ -1,155 +1,148 @@
-﻿using FastAndFaster.Tests.DummyClasses;
-using FluentAssertions;
-using System;
-using System.Collections.Generic;
-using Xunit;
+﻿namespace FastAndFaster.Tests;
 
-namespace FastAndFaster.Tests
+public class InvocatorStaticTests
 {
-    public class InvocatorStaticTests
+    [Fact]
+    public void ShouldCallParameterlessAction()
     {
-        [Fact]
-        public void ShouldCallParameterlessAction()
+        // Arrange
+        InvocationStaticTarget.ActionParameterlessCalled = false;
+        var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationStaticTarget.ActionParameterless);
+        var invocator = Invocator.CreateAction(typeName, methodName);
+
+        // Act
+        invocator(null, null);
+
+        // Assert
+        InvocationStaticTarget.ActionParameterlessCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCallAction_ValueTypeParameter()
+    {
+        // Arrange
+        InvocationStaticTarget.ActionHandleValData = 0;
+        var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationStaticTarget.ActionHandleVal);
+        var parameterTypes = new[] { typeof(int), typeof(int) };
+        var first = 17;
+        var second = 89;
+        var parameters = new object[] { first, second };
+        var expectedResult = 17 + 89;
+        var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
+
+        // Act
+        invocator(null, parameters);
+
+        // Assert
+        InvocationStaticTarget.ActionHandleValData.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void ShouldCallAction_ReferenceTypeParameter()
+    {
+        // Arrange
+        InvocationStaticTarget.ActionHandleRefData = null;
+        var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationStaticTarget.ActionHandleRef);
+        var parameterTypes = new[] { typeof(List<string>), typeof(string) };
+        var parameters = new object[]
         {
-            // Arrange
-            InvocationStaticTarget.ActionParameterlessCalled = false;
-            var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationStaticTarget.ActionParameterless);
-            var invocator = Invocator.CreateAction(typeName, methodName);
+            new List<string> { "Duong", "Luy" },
+            "Nana"
+        };
+        var expectedResult = new List<string> { "Duong", "Luy", "Nana" };
+        var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
 
-            // Act
-            invocator(null, null);
+        // Act
+        invocator(null, parameters);
 
-            // Assert
-            InvocationStaticTarget.ActionParameterlessCalled.Should().BeTrue();
-        }
+        // Assert
+        InvocationStaticTarget.ActionHandleRefData.Should().BeEquivalentTo(expectedResult);
+    }
 
-        [Fact]
-        public void ShouldCallAction_ValueTypeParameter()
+    public static IEnumerable<object[]> StaticFuncData() =>
+        new List<object[]>
         {
-            // Arrange
-            InvocationStaticTarget.ActionHandleValData = 0;
-            var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationStaticTarget.ActionHandleVal);
-            var parameterTypes = new[] { typeof(int), typeof(int) };
-            var first = 17;
-            var second = 89;
-            var parameters = new object[] { first, second };
-            var expectedResult = 17 + 89;
-            var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
-
-            // Act
-            invocator(null, parameters);
-
-            // Assert
-            InvocationStaticTarget.ActionHandleValData.Should().Be(expectedResult);
-        }
-
-        [Fact]
-        public void ShouldCallAction_ReferenceTypeParameter()
-        {
-            // Arrange
-            InvocationStaticTarget.ActionHandleRefData = null;
-            var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationStaticTarget.ActionHandleRef);
-            var parameterTypes = new[] { typeof(List<string>), typeof(string) };
-            var parameters = new object[]
+            new object[]
             {
-                new List<string> { "Duong", "Luy" },
-                "Nana"
-            };
-            var expectedResult = new List<string> { "Duong", "Luy", "Nana" };
-            var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
-
-            // Act
-            invocator(null, parameters);
-
-            // Assert
-            InvocationStaticTarget.ActionHandleRefData.Should().BeEquivalentTo(expectedResult);
-        }
-
-        public static IEnumerable<object[]> StaticFuncData() =>
-            new List<object[]>
+                nameof(InvocationStaticTarget.FuncHandleVal),
+                new[] { typeof(int), typeof(int) },
+                new object[] { 17, 89 },
+                17 + 89
+            },
+            new object[]
             {
+                nameof(InvocationStaticTarget.FuncHandleRef),
+                new[] { typeof(List<string>), typeof(string) },
                 new object[]
                 {
-                    nameof(InvocationStaticTarget.FuncHandleVal),
-                    new[] { typeof(int), typeof(int) },
-                    new object[] { 17, 89 },
-                    17 + 89
+                    new List<string> { "Duong", "Luy" },
+                    "Nana"
                 },
-                new object[]
-                {
-                    nameof(InvocationStaticTarget.FuncHandleRef),
-                    new[] { typeof(List<string>), typeof(string) },
-                    new object[]
-                    {
-                        new List<string> { "Duong", "Luy" },
-                        "Nana"
-                    },
-                    new List<string> { "Duong", "Luy", "Nana" }
-                },
-                new object[]
-                {
-                    nameof(InvocationStaticTarget.FuncParameterless),
-                    Type.EmptyTypes,
-                    null,
-                    InvocationStaticTarget.FuncParameterlessData
-                }
-            };
+                new List<string> { "Duong", "Luy", "Nana" }
+            },
+            new object[]
+            {
+                nameof(InvocationStaticTarget.FuncParameterless),
+                Type.EmptyTypes,
+                null,
+                InvocationStaticTarget.FuncParameterlessData
+            }
+        };
 
-        [Theory]
-        [MemberData(nameof(StaticFuncData))]
-        public void ShouldCallStaticFunc(
-            string methodName, Type[] parameterTypes, object[] parameters, object expectedResult)
-        {
-            // Arrange
-            var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
-            var invocator = Invocator.CreateFunc(typeName, methodName, parameterTypes);
+    [Theory]
+    [MemberData(nameof(StaticFuncData))]
+    public void ShouldCallStaticFunc(
+        string methodName, Type[] parameterTypes, object[] parameters, object expectedResult)
+    {
+        // Arrange
+        var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
+        var invocator = Invocator.CreateFunc(typeName, methodName, parameterTypes);
 
-            // Act
-            var rs = invocator(null, parameters);
+        // Act
+        var rs = invocator(null, parameters);
 
-            // Assert
-            rs.Should().BeEquivalentTo(expectedResult);
-        }
+        // Assert
+        rs.Should().BeEquivalentTo(expectedResult);
+    }
 
-        [Fact]
-        public void ShouldCallStaticFunc_InterfaceInput()
-        {
-            // Arrange
-            var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationStaticTarget.FuncWithInterface);
-            var argumentTypes = new[] { typeof(IEnumerable<string>) };
-            var names = new List<string> { "First", "Second", "Third", "Fourth" };
-            var arguments = new object[] { names };
-            var expectedRs = names.Count;
-            var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
+    [Fact]
+    public void ShouldCallStaticFunc_InterfaceInput()
+    {
+        // Arrange
+        var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationStaticTarget.FuncWithInterface);
+        var argumentTypes = new[] { typeof(IEnumerable<string>) };
+        var names = new List<string> { "First", "Second", "Third", "Fourth" };
+        var arguments = new object[] { names };
+        var expectedRs = names.Count;
+        var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
 
-            // Act
-            var rs = invocator(null, arguments);
+        // Act
+        var rs = invocator(null, arguments);
 
-            // Assert
-            rs.Should().BeEquivalentTo(expectedRs);
-        }
+        // Assert
+        rs.Should().BeEquivalentTo(expectedRs);
+    }
 
-        [Fact]
-        public void ShouldCallStaticAction_InterfaceInput()
-        {
-            // Arrange
-            var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationStaticTarget.ActionWithInterface);
-            var argumentTypes = new[] { typeof(IEnumerable<int>) };
-            var ages = new List<int> { 5, 6, 7 };
-            var arguments = new object[] { ages };
-            var expectedRs = ages.Count;
-            var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes);
+    [Fact]
+    public void ShouldCallStaticAction_InterfaceInput()
+    {
+        // Arrange
+        var typeName = typeof(InvocationStaticTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationStaticTarget.ActionWithInterface);
+        var argumentTypes = new[] { typeof(IEnumerable<int>) };
+        var ages = new List<int> { 5, 6, 7 };
+        var arguments = new object[] { ages };
+        var expectedRs = ages.Count;
+        var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes);
 
-            // Act
-            invocator(null, arguments);
+        // Act
+        invocator(null, arguments);
 
-            // Assert
-            InvocationStaticTarget.InterfaceTestData.Should().Be(expectedRs);
-        }
+        // Assert
+        InvocationStaticTarget.InterfaceTestData.Should().Be(expectedRs);
     }
 }

--- a/FastAndFaster.Tests/InvocatorTests.cs
+++ b/FastAndFaster.Tests/InvocatorTests.cs
@@ -1,449 +1,442 @@
-﻿using FastAndFaster.Tests.DummyClasses;
-using FluentAssertions;
-using System;
-using System.Collections.Generic;
-using Xunit;
+﻿namespace FastAndFaster.Tests;
 
-namespace FastAndFaster.Tests
+public class InvocatorTests
 {
-    public class InvocatorTests
+    public static IEnumerable<object[]> CallParameterlessActionData()
     {
-        public static IEnumerable<object[]> CallParameterlessActionData()
-        {
-            var target = new InvocationTarget();
-            var childTarget = new ChildInvocationTarget();
+        var target = new InvocationTarget();
+        var childTarget = new ChildInvocationTarget();
 
-            return new List<object[]>
+        return new List<object[]>
+        {
+            new object[] { target, nameof(InvocationTarget.ParameterlessAction) },
+            // Call a method defined in parent class
+            new object[] { childTarget, nameof(ChildInvocationTarget.ParameterlessAction) }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(CallParameterlessActionData))]
+    public void ShouldCallAction_Parameterless(dynamic target, string methodName)
+    {
+        // Arrange
+        var typeName = target.GetType().AssemblyQualifiedName;
+        var invocator = Invocator.CreateAction(typeName, methodName);
+
+        // Act
+        invocator(target, null);
+
+        // Assert
+        Assert.True(target.ParameterlessActionCalled);
+    }
+
+    public static IEnumerable<object[]> CallActionWithParameterData()
+    {
+        var target = new InvocationTarget();
+        var childTarget = new ChildInvocationTarget();
+
+        return new List<object[]>
+        {
+            new object[]
             {
-                new object[] { target, nameof(InvocationTarget.ParameterlessAction) },
+                target, target.GetType().AssemblyQualifiedName, nameof(InvocationTarget.Action)
+            },
+            new object[]
+            {
+                // Call the action via interface
+                target, typeof(IInvocationTarget).AssemblyQualifiedName, nameof(InvocationTarget.Action)
+            },
+            new object[]
+            {
                 // Call a method defined in parent class
-                new object[] { childTarget, nameof(ChildInvocationTarget.ParameterlessAction) }
-            };
-        }
+                childTarget, target.GetType().AssemblyQualifiedName, nameof(ChildInvocationTarget.Action)
+            }
+        };
+    }
 
-        [Theory]
-        [MemberData(nameof(CallParameterlessActionData))]
-        public void ShouldCallAction_Parameterless(dynamic target, string methodName)
+    [Theory]
+    [MemberData(nameof(CallActionWithParameterData))]
+    public void ShouldCallAction_HasParameter(dynamic target, string typeName, string methodName)
+    {
+        // Arrange
+        var name = "Duong";
+        var age = 32;
+        var parameters = new object[] { name, age };
+        var parameterTypes = new[] { typeof(string), typeof(int) };
+        var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
+
+        // Act
+        invocator(target, parameters);
+
+        // Assert
+        Assert.Equal(target.ActionData, (name, age));
+    }
+
+    public static IEnumerable<object[]> CallParameterlessFuncData()
+    {
+        var refExpectedData = "thai duong";
+        var refTarget = new InvocationTarget { ParameterlessFuncReturnRefData = refExpectedData };
+        var childRefTarget = new ChildInvocationTarget { ParameterlessFuncReturnRefData = refExpectedData };
+        var valExpectedData = 17;
+        var valTarget = new InvocationTarget { ParameterlessFuncReturnValData = valExpectedData };
+        var childValTarget = new ChildInvocationTarget { ParameterlessFuncReturnValData = valExpectedData };
+
+        return new List<object[]>
         {
-            // Arrange
-            var typeName = target.GetType().AssemblyQualifiedName;
-            var invocator = Invocator.CreateAction(typeName, methodName);
-
-            // Act
-            invocator(target, null);
-
-            // Assert
-            Assert.True(target.ParameterlessActionCalled);
-        }
-
-        public static IEnumerable<object[]> CallActionWithParameterData()
-        {
-            var target = new InvocationTarget();
-            var childTarget = new ChildInvocationTarget();
-
-            return new List<object[]>
+            new object[]
             {
-                new object[]
-                {
-                    target, target.GetType().AssemblyQualifiedName, nameof(InvocationTarget.Action)
-                },
-                new object[]
-                {
-                    // Call the action via interface
-                    target, typeof(IInvocationTarget).AssemblyQualifiedName, nameof(InvocationTarget.Action)
-                },
-                new object[]
-                {
-                    // Call a method defined in parent class
-                    childTarget, target.GetType().AssemblyQualifiedName, nameof(ChildInvocationTarget.Action)
-                }
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(CallActionWithParameterData))]
-        public void ShouldCallAction_HasParameter(dynamic target, string typeName, string methodName)
-        {
-            // Arrange
-            var name = "Duong";
-            var age = 32;
-            var parameters = new object[] { name, age };
-            var parameterTypes = new[] { typeof(string), typeof(int) };
-            var invocator = Invocator.CreateAction(typeName, methodName, parameterTypes);
-
-            // Act
-            invocator(target, parameters);
-
-            // Assert
-            Assert.Equal(target.ActionData, (name, age));
-        }
-
-        public static IEnumerable<object[]> CallParameterlessFuncData()
-        {
-            var refExpectedData = "thai duong";
-            var refTarget = new InvocationTarget { ParameterlessFuncReturnRefData = refExpectedData };
-            var childRefTarget = new ChildInvocationTarget { ParameterlessFuncReturnRefData = refExpectedData };
-            var valExpectedData = 17;
-            var valTarget = new InvocationTarget { ParameterlessFuncReturnValData = valExpectedData };
-            var childValTarget = new ChildInvocationTarget { ParameterlessFuncReturnValData = valExpectedData };
-
-            return new List<object[]>
+                refTarget, nameof(InvocationTarget.ParameterlessFuncReturnRef), refExpectedData
+            },
+            new object[]
             {
-                new object[]
-                {
-                    refTarget, nameof(InvocationTarget.ParameterlessFuncReturnRef), refExpectedData
-                },
-                new object[]
-                {
-                    valTarget, nameof(InvocationTarget.ParameterlessFuncReturnVal), valExpectedData
-                },
-                // In the next 2 cases, call methods defined in parent class
-                new object[]
-                {
-                    childRefTarget, nameof(ChildInvocationTarget.ParameterlessFuncReturnRef), refExpectedData
-                },
-                new object[]
-                {
-                    childValTarget, nameof(ChildInvocationTarget.ParameterlessFuncReturnVal), valExpectedData
-                },
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(CallParameterlessFuncData))]
-        public void ShouldCallFunc_Parameterless(object target, string methodName, object expectedResult)
-        {
-            // Arrange
-            var typeName = target.GetType().AssemblyQualifiedName;
-            var invocator = Invocator.CreateFunc(typeName, methodName);
-
-            // Act
-            var rs = invocator(target, null);
-
-            // Assert
-            rs.Should().Be(expectedResult);
-        }
-
-        public static List<object[]> CallFuncWithParameterData()
-        {
-            var names = new List<string> { "Duong", "Luy" };
-            var name = "Nana";
-            var refArguments = new object[] { names, name };
-            var refArgumentTypes = new[] { typeof(List<string>), typeof(string) };
-            var refExpectedResult = new List<string> { "Duong", "Luy", "Nana" };
-
-            var firstNumber = 17;
-            var secondNumber = 10;
-            var valArgumentTypes = new[] { typeof(int), typeof(int) };
-            var valArguments = new object[] { firstNumber, secondNumber };
-            var valExpectedResult = firstNumber + secondNumber;
-
-            return new List<object[]>
+                valTarget, nameof(InvocationTarget.ParameterlessFuncReturnVal), valExpectedData
+            },
+            // In the next 2 cases, call methods defined in parent class
+            new object[]
             {
-                new object[]
-                {
-                    typeof(InvocationTarget).AssemblyQualifiedName, nameof(InvocationTarget.FuncHandleRef),
-                    refArgumentTypes, refArguments, refExpectedResult
-                },
-                new object[]
-                {
-                    typeof(InvocationTarget).AssemblyQualifiedName, nameof(ChildInvocationTarget.FuncHandleVal),
-                    valArgumentTypes, valArguments, valExpectedResult
-                },
-                // In the next 2 cases, the functions are called via interface
-                new object[]
-                {
-                    typeof(IInvocationTarget).AssemblyQualifiedName, nameof(InvocationTarget.FuncHandleRef),
-                    refArgumentTypes, refArguments, refExpectedResult
-                },
-                new object[]
-                {
-                    typeof(IInvocationTarget).AssemblyQualifiedName, nameof(ChildInvocationTarget.FuncHandleVal),
-                    valArgumentTypes, valArguments, valExpectedResult
-                }
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(CallFuncWithParameterData))]
-        public void ShouldCallFunc_WithParameter(
-            string typeName, string methodName, Type[] argumentTypes, object[] arguments, object expectedResult)
-        {
-            // Arrange
-            var target = new InvocationTarget();
-            var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
-
-            // Act
-            var rs = invocator(target, arguments);
-
-            // Assert
-            rs.Should().BeEquivalentTo(expectedResult);
-        }
-
-        [Fact]
-        public void ShouldCallAction_Overload()
-        {
-            // Arrange
-            var target = new InvocationTarget();
-            var typeName = target.GetType().AssemblyQualifiedName;
-            var methodName = nameof(InvocationTarget.OverloadAction);
-            var invocator = Invocator.CreateAction(typeName, methodName);
-
-            // Act
-            invocator(target, null);
-
-            // Assert
-            target.OverloadActionCalled.Should().BeTrue();
-        }
-
-        public static IEnumerable<object[]> CallFuncOverloadData()
-        {
-            var name = "Duong";
-            var singleArgumentType = new[] { typeof(string) };
-            var singleArgument = new object[] { name };
-            var expectedResultForSingle = name;
-
-            var firstNumber = 17;
-            var secondNumber = 10;
-            var multiArgumentTypes = new[] { typeof(int), typeof(int) };
-            var multiArguments = new object[] { firstNumber, secondNumber };
-            var expectedResultForMulti = firstNumber + secondNumber;
-
-            return new List<object[]>
+                childRefTarget, nameof(ChildInvocationTarget.ParameterlessFuncReturnRef), refExpectedData
+            },
+            new object[]
             {
-                new object[]
-                {
-                    singleArgumentType, singleArgument, expectedResultForSingle
-                },
-                new object[]
-                {
-                    multiArgumentTypes, multiArguments, expectedResultForMulti
-                },
-            };
-        }
+                childValTarget, nameof(ChildInvocationTarget.ParameterlessFuncReturnVal), valExpectedData
+            },
+        };
+    }
 
-        [Theory]
-        [MemberData(nameof(CallFuncOverloadData))]
-        public void ShouldCallFunc_Overload(Type[] argumentTypes, object[] arguments, object expectedResult)
+    [Theory]
+    [MemberData(nameof(CallParameterlessFuncData))]
+    public void ShouldCallFunc_Parameterless(object target, string methodName, object expectedResult)
+    {
+        // Arrange
+        var typeName = target.GetType().AssemblyQualifiedName;
+        var invocator = Invocator.CreateFunc(typeName, methodName);
+
+        // Act
+        var rs = invocator(target, null);
+
+        // Assert
+        rs.Should().Be(expectedResult);
+    }
+
+    public static List<object[]> CallFuncWithParameterData()
+    {
+        var names = new List<string> { "Duong", "Luy" };
+        var name = "Nana";
+        var refArguments = new object[] { names, name };
+        var refArgumentTypes = new[] { typeof(List<string>), typeof(string) };
+        var refExpectedResult = new List<string> { "Duong", "Luy", "Nana" };
+
+        var firstNumber = 17;
+        var secondNumber = 10;
+        var valArgumentTypes = new[] { typeof(int), typeof(int) };
+        var valArguments = new object[] { firstNumber, secondNumber };
+        var valExpectedResult = firstNumber + secondNumber;
+
+        return new List<object[]>
         {
-            // Arrange
-            var target = new InvocationTarget();
-            var typeName = target.GetType().AssemblyQualifiedName;
-            var methodName = nameof(InvocationTarget.OverloadFunc);
-            var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
-
-            // Act
-            var rs = invocator(target, arguments);
-
-            // Assert
-            rs.Should().Be(expectedResult);
-        }
-
-        [Fact]
-        public void CallVirtualAction()
-        {
-            // Arrange
-            var target = new ChildInvocationTarget();
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationTarget.VirtualAction);
-            var argumentTypes = new[] { typeof(int), typeof(int) };
-            var arguments = new object[] { 19, 89 };
-            var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes);
-
-            // Act
-            invocator(target, arguments);
-
-            // Assert
-            // The overrided version ChildInvocationTarget.VirtualAction should be called
-            // even though the target is used as an InvocationTarget.
-            target.VirtualActionCalled.Should().BeFalse();
-            target.ChildVirtualActionCalled.Should().BeTrue();
-        }
-
-        public static IEnumerable<object[]> CallVirtualFuncData()
-        {
-            var expectedResult = "Virtual function from parent";
-            var target = new InvocationTarget { VirtualFuncData = expectedResult };
-            var childExpectedResult = "Virtual function from child";
-            var childTarget = new ChildInvocationTarget { ChildVirtualFuncData = childExpectedResult };
-
-            return new List<object[]>
+            new object[]
             {
-                new object[]
-                {
-                    target, expectedResult
-                },
-                new object[]
-                {
-                    // The overrided version ChildInvocationTarget.VirtualFunc should be called
-                    // even though the target is used as an InvocationTarget.
-                    childTarget, childExpectedResult
-                }
-            };
-        }
-
-        [Theory]
-        [MemberData(nameof(CallVirtualFuncData))]
-        public void ShouldCallFunc_Virtual(object target, string expectedResult)
-        {
-            // Arrange
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-            var methodName = nameof(InvocationTarget.VirtualFunc);
-            var invocator = Invocator.CreateFunc(typeName, methodName, Type.EmptyTypes);
-
-            // Act
-            var rs = invocator(target, null);
-
-            // Assert
-            rs.Should().Be(expectedResult);
-        }
-
-        [Fact]
-        public void ShouldThrowException_CreateFunc_TypeNameNotFound()
-        {
-            // Arrange
-            var fakeTypeName = "dummy";
-            var fakeMethodName = "dummy";
-
-            // Act
-            Func<object> action = () => Invocator.CreateFunc(fakeTypeName, fakeMethodName);
-
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find any class with Assembly Qualified Name: {fakeTypeName}");
-        }
-
-        public static IEnumerable<object[]> CreateFuncIncorrectSignatureData() =>
-            new List<object[]>
+                typeof(InvocationTarget).AssemblyQualifiedName, nameof(InvocationTarget.FuncHandleRef),
+                refArgumentTypes, refArguments, refExpectedResult
+            },
+            new object[]
             {
-                new object[] { "fakename", Type.EmptyTypes },
-                new object[]
-                {
-                    nameof(InvocationTarget.FuncHandleRef),
-                    new[] { typeof(double), typeof(long) } // Wrong types
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(CreateFuncIncorrectSignatureData))]
-        public void ShouldThrowException_CreateFunc_IncorrectSignature(string methodName, Type[] argumentTypes)
-        {
-            // Arrange
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-
-            // Act
-            Func<object> action = () => Invocator.CreateFunc(typeName, methodName, argumentTypes);
-
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find method [{methodName}] with the given signature");
-        }
-
-        [Fact]
-        public void ShouldThrowException_CreateAction_TypeNameNotFound()
-        {
-            // Arrange
-            var fakeTypeName = "dummy";
-            var fakeMethodName = "dummy";
-
-            // Act
-            Func<object> action = () => Invocator.CreateAction(fakeTypeName, fakeMethodName);
-
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find any class with Assembly Qualified Name: {fakeTypeName}");
-        }
-
-        public static IEnumerable<object[]> CreateActionIncorrectSignatureData() =>
-            new List<object[]>
+                typeof(InvocationTarget).AssemblyQualifiedName, nameof(ChildInvocationTarget.FuncHandleVal),
+                valArgumentTypes, valArguments, valExpectedResult
+            },
+            // In the next 2 cases, the functions are called via interface
+            new object[]
             {
-                new object[] { "fakename", Type.EmptyTypes },
-                new object[]
-                {
-                    nameof(InvocationTarget.Action),
-                    new[] { typeof(double), typeof(long) } // Wrong type
-                }
-            };
-
-        [Theory]
-        [MemberData(nameof(CreateFuncIncorrectSignatureData))]
-        public void ShouldThrowException_CreateAction_IncorrectSignature(string methodName, Type[] argumentTypes)
-        {
-            // Arrange
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-
-            // Act
-            Func<object> action = () => Invocator.CreateAction(typeName, methodName, argumentTypes);
-
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find method [{methodName}] with the given signature");
-        }
-
-        [Fact]
-        public void ShouldNotCallNonVisibleAction()
-        {
-            // Arrange
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-            var methodName = "PrivateAction";
-
-            // Act
-            Func<object> action = () => Invocator.CreateAction(typeName, methodName);
-
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find method [{methodName}] with the given signature");
-        }
-
-        [Fact]
-        public void ShouldNotCallNonVisibleFunc()
-        {
-            // Arrange
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-            var methodName = "PrivateFunc";
-
-            // Act
-            Func<object> action = () => Invocator.CreateFunc(typeName, methodName);
-
-            // Assert
-            action.Should().Throw<ArgumentException>()
-                .WithMessage($"Cannot find method [{methodName}] with the given signature");
-        }
-
-        public static IEnumerable<object[]> InterfaceData() =>
-            new List<object[]>
+                typeof(IInvocationTarget).AssemblyQualifiedName, nameof(InvocationTarget.FuncHandleRef),
+                refArgumentTypes, refArguments, refExpectedResult
+            },
+            new object[]
             {
-                new object[]
-                {
-                    nameof(InvocationTarget.InterfaceInput),
-                    new[] { typeof(IEnumerable<string>) },
-                    new object[] { new List<string> { "Duong", "Luy", "Nana" } },
-                    3
-                },
-                new object[]
-                {
-                    nameof(InvocationTarget.InterfaceOutput),
-                    new[] { typeof(int) },
-                    new object[] { 3 },
-                    new List<int> { 0, 1, 2 }
-                }
-            };
+                typeof(IInvocationTarget).AssemblyQualifiedName, nameof(ChildInvocationTarget.FuncHandleVal),
+                valArgumentTypes, valArguments, valExpectedResult
+            }
+        };
+    }
 
-        [Theory]
-        [MemberData(nameof(InterfaceData))]
-        public void ShouldCallMethod_InterfaceInputOrOutput(
-            string methodName, Type[] argumentTypes, object[] arguments, object expectedRs)
+    [Theory]
+    [MemberData(nameof(CallFuncWithParameterData))]
+    public void ShouldCallFunc_WithParameter(
+        string typeName, string methodName, Type[] argumentTypes, object[] arguments, object expectedResult)
+    {
+        // Arrange
+        var target = new InvocationTarget();
+        var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
+
+        // Act
+        var rs = invocator(target, arguments);
+
+        // Assert
+        rs.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Fact]
+    public void ShouldCallAction_Overload()
+    {
+        // Arrange
+        var target = new InvocationTarget();
+        var typeName = target.GetType().AssemblyQualifiedName;
+        var methodName = nameof(InvocationTarget.OverloadAction);
+        var invocator = Invocator.CreateAction(typeName, methodName);
+
+        // Act
+        invocator(target, null);
+
+        // Assert
+        target.OverloadActionCalled.Should().BeTrue();
+    }
+
+    public static IEnumerable<object[]> CallFuncOverloadData()
+    {
+        var name = "Duong";
+        var singleArgumentType = new[] { typeof(string) };
+        var singleArgument = new object[] { name };
+        var expectedResultForSingle = name;
+
+        var firstNumber = 17;
+        var secondNumber = 10;
+        var multiArgumentTypes = new[] { typeof(int), typeof(int) };
+        var multiArguments = new object[] { firstNumber, secondNumber };
+        var expectedResultForMulti = firstNumber + secondNumber;
+
+        return new List<object[]>
         {
-            // Arrange
-            var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
-            var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
-            var target = new InvocationTarget();
+            new object[]
+            {
+                singleArgumentType, singleArgument, expectedResultForSingle
+            },
+            new object[]
+            {
+                multiArgumentTypes, multiArguments, expectedResultForMulti
+            },
+        };
+    }
 
-            // Act
-            var rs = invocator(target, arguments);
+    [Theory]
+    [MemberData(nameof(CallFuncOverloadData))]
+    public void ShouldCallFunc_Overload(Type[] argumentTypes, object[] arguments, object expectedResult)
+    {
+        // Arrange
+        var target = new InvocationTarget();
+        var typeName = target.GetType().AssemblyQualifiedName;
+        var methodName = nameof(InvocationTarget.OverloadFunc);
+        var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
 
-            // Assert
-            rs.Should().BeEquivalentTo(expectedRs);
-        }
+        // Act
+        var rs = invocator(target, arguments);
+
+        // Assert
+        rs.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void CallVirtualAction()
+    {
+        // Arrange
+        var target = new ChildInvocationTarget();
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationTarget.VirtualAction);
+        var argumentTypes = new[] { typeof(int), typeof(int) };
+        var arguments = new object[] { 19, 89 };
+        var invocator = Invocator.CreateAction(typeName, methodName, argumentTypes);
+
+        // Act
+        invocator(target, arguments);
+
+        // Assert
+        // The overrided version ChildInvocationTarget.VirtualAction should be called
+        // even though the target is used as an InvocationTarget.
+        target.VirtualActionCalled.Should().BeFalse();
+        target.ChildVirtualActionCalled.Should().BeTrue();
+    }
+
+    public static IEnumerable<object[]> CallVirtualFuncData()
+    {
+        var expectedResult = "Virtual function from parent";
+        var target = new InvocationTarget { VirtualFuncData = expectedResult };
+        var childExpectedResult = "Virtual function from child";
+        var childTarget = new ChildInvocationTarget { ChildVirtualFuncData = childExpectedResult };
+
+        return new List<object[]>
+        {
+            new object[]
+            {
+                target, expectedResult
+            },
+            new object[]
+            {
+                // The overrided version ChildInvocationTarget.VirtualFunc should be called
+                // even though the target is used as an InvocationTarget.
+                childTarget, childExpectedResult
+            }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(CallVirtualFuncData))]
+    public void ShouldCallFunc_Virtual(object target, string expectedResult)
+    {
+        // Arrange
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+        var methodName = nameof(InvocationTarget.VirtualFunc);
+        var invocator = Invocator.CreateFunc(typeName, methodName, Type.EmptyTypes);
+
+        // Act
+        var rs = invocator(target, null);
+
+        // Assert
+        rs.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void ShouldThrowException_CreateFunc_TypeNameNotFound()
+    {
+        // Arrange
+        var fakeTypeName = "dummy";
+        var fakeMethodName = "dummy";
+
+        // Act
+        Func<object> action = () => Invocator.CreateFunc(fakeTypeName, fakeMethodName);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find any class with Assembly Qualified Name: {fakeTypeName}");
+    }
+
+    public static IEnumerable<object[]> CreateFuncIncorrectSignatureData() =>
+        new List<object[]>
+        {
+            new object[] { "fakename", Type.EmptyTypes },
+            new object[]
+            {
+                nameof(InvocationTarget.FuncHandleRef),
+                new[] { typeof(double), typeof(long) } // Wrong types
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(CreateFuncIncorrectSignatureData))]
+    public void ShouldThrowException_CreateFunc_IncorrectSignature(string methodName, Type[] argumentTypes)
+    {
+        // Arrange
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+
+        // Act
+        Func<object> action = () => Invocator.CreateFunc(typeName, methodName, argumentTypes);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find method [{methodName}] with the given signature");
+    }
+
+    [Fact]
+    public void ShouldThrowException_CreateAction_TypeNameNotFound()
+    {
+        // Arrange
+        var fakeTypeName = "dummy";
+        var fakeMethodName = "dummy";
+
+        // Act
+        Func<object> action = () => Invocator.CreateAction(fakeTypeName, fakeMethodName);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find any class with Assembly Qualified Name: {fakeTypeName}");
+    }
+
+    public static IEnumerable<object[]> CreateActionIncorrectSignatureData() =>
+        new List<object[]>
+        {
+            new object[] { "fakename", Type.EmptyTypes },
+            new object[]
+            {
+                nameof(InvocationTarget.Action),
+                new[] { typeof(double), typeof(long) } // Wrong type
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(CreateFuncIncorrectSignatureData))]
+    public void ShouldThrowException_CreateAction_IncorrectSignature(string methodName, Type[] argumentTypes)
+    {
+        // Arrange
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+
+        // Act
+        Func<object> action = () => Invocator.CreateAction(typeName, methodName, argumentTypes);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find method [{methodName}] with the given signature");
+    }
+
+    [Fact]
+    public void ShouldNotCallNonVisibleAction()
+    {
+        // Arrange
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+        var methodName = "PrivateAction";
+
+        // Act
+        Func<object> action = () => Invocator.CreateAction(typeName, methodName);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find method [{methodName}] with the given signature");
+    }
+
+    [Fact]
+    public void ShouldNotCallNonVisibleFunc()
+    {
+        // Arrange
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+        var methodName = "PrivateFunc";
+
+        // Act
+        Func<object> action = () => Invocator.CreateFunc(typeName, methodName);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage($"Cannot find method [{methodName}] with the given signature");
+    }
+
+    public static IEnumerable<object[]> InterfaceData() =>
+        new List<object[]>
+        {
+            new object[]
+            {
+                nameof(InvocationTarget.InterfaceInput),
+                new[] { typeof(IEnumerable<string>) },
+                new object[] { new List<string> { "Duong", "Luy", "Nana" } },
+                3
+            },
+            new object[]
+            {
+                nameof(InvocationTarget.InterfaceOutput),
+                new[] { typeof(int) },
+                new object[] { 3 },
+                new List<int> { 0, 1, 2 }
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(InterfaceData))]
+    public void ShouldCallMethod_InterfaceInputOrOutput(
+        string methodName, Type[] argumentTypes, object[] arguments, object expectedRs)
+    {
+        // Arrange
+        var typeName = typeof(InvocationTarget).AssemblyQualifiedName;
+        var invocator = Invocator.CreateFunc(typeName, methodName, argumentTypes);
+        var target = new InvocationTarget();
+
+        // Act
+        var rs = invocator(target, arguments);
+
+        // Assert
+        rs.Should().BeEquivalentTo(expectedRs);
     }
 }

--- a/FastAndFaster/FastAndFaster.csproj
+++ b/FastAndFaster/FastAndFaster.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET Core 3.1 will reach EOS in 2022/12. This PR is to:
- Switch the main library to .NET Standard 2.1.
- Upgrade test projects to .NET 6.

At the moment, I don't think it's necessary to upgrade the main library to .NET 6.